### PR TITLE
fix: make udp4 default more resilient

### DIFF
--- a/server/udp.js
+++ b/server/udp.js
@@ -10,7 +10,7 @@ class Server extends udp.Socket {
   constructor(options) {
     let type = 'udp4';
     if (typeof options === 'object') {
-      type = options.type;
+      type = options.type ?? type;
     }
     super(type);
     if (typeof options === 'function') {


### PR DESCRIPTION
If 'type' was not specified in an object argument to the constructor of UDPSocket, it would result in an undefined value. This is probably not what the user intended and it always results in an exception being thrown.