### PR TITLE
Remove invalid pathname auto-completion and enforce RFC8484 dns query parameter

### DIFF
--- a/client/doh.js
+++ b/client/doh.js
@@ -37,11 +37,16 @@ const makeRequest = (url, query) => new Promise((resolve, reject) => {
   const index = url.indexOf('://');
   if (index === -1) url = `https://${url}`;
   const u = new URL(url);
+  // The DNS query is included in a single variable named “dns” in the
+  // query component of the request URI.  The value of the “dns” variable
+  // is the content of the DNS request message, encoded with base64url
+  // [RFC4648](https://datatracker.ietf.org/doc/html/rfc8484#section-4.1).
+  const searchParams = u.searchParams;
+  searchParams.set('dns', query);
+  u.search = searchParams.toString();
   const get = protocols[u.protocol];
   if (!get) throw new Error(`Unsupported protocol: ${u.protocol}, must be specified (http://, https:// or h2://)`);
-  if (!u.pathname) url += '/dns-query?dns={query}';
-  url = url.replace('{query}', query);
-  const req = get(url, { headers: { accept: 'application/dns-message' } }, resolve);
+  const req = get(u.toString(), { headers: { accept: 'application/dns-message' } }, resolve);
   if (req) req.on('error', reject);
 });
 

--- a/example/client/doh.js
+++ b/example/client/doh.js
@@ -18,5 +18,5 @@ const { DOHClient } = require('../..');
 // })('cdnjs.com', 'NS').then(console.log);
 
 DOHClient({
-  dns: 'h2://ada.openbld.net/dns-query?dns={query}',
+  dns: 'https://1.0.0.1/dns-query',
 })('cdnjs.com', 'NS').then(console.log);


### PR DESCRIPTION
This PR makes the following changes:
1.	Remove pathname auto-completion logic
	•	The existing check `u.pathname == ''` never works in Node.js, since URL.pathname is always at least /.
	•	As a result, the auto-completion logic was effectively dead code and has been removed.
2.	Enforce RFC8484 §4.1 requirement for the dns query parameter
	•	According to [RFC8484 §4.1](https://datatracker.ietf.org/doc/html/rfc8484#section-4.1), a DoH GET request must include the DNS query in a single query parameter named `dns`, encoded with base64url.
	•	Custom query parameter names and `{query}` substitution are therefore no longer supported.


#95 